### PR TITLE
Update and renamed __resource.lua to fxmanifest

### DIFF
--- a/esx_weatherchange/fxmanifest.lua
+++ b/esx_weatherchange/fxmanifest.lua
@@ -1,4 +1,5 @@
-resource_manifest_version '05cfa83c-a124-4cfa-a768-c24a5811d8f9'
+fx_version "cerulean"
+game "gta5"
 
 client_scripts {
     "@NativeUI/NativeUI.lua",


### PR DESCRIPTION
__resourse.lua is old and shall not be used anymore. We now use fxmanifest.lua to start the resource. You can find documentation here: https://docs.fivem.net/docs/scripting-reference/resource-manifest/resource-manifest/